### PR TITLE
Fix CLI prompt and default path in CSV consolidator

### DIFF
--- a/tables_consolidate.py
+++ b/tables_consolidate.py
@@ -182,7 +182,7 @@ def main():
                 'output_file',
                 message="Enter the output CSV file path",
                 path_type=inquirer.Path.FILE,
-                default=str(Path(input_directory) / "prompts_ftable.csv")
+                default=str(Path(input_directory) / "consolidated.csv")
             )
         ]
 
@@ -191,7 +191,7 @@ def main():
             print("Operation cancelled.")
             return 1
 
-            output_file = output_file_answers['output_file']
+        output_file = output_file_answers['output_file']
 
     # Perform consolidation
     try:


### PR DESCRIPTION
## Summary
- fix indentation bug when reading custom output path
- point CLI default output path to `consolidated.csv`

## Testing
- `python -m py_compile tables_consolidate.py`
- `python tables_consolidate.py <<'EOF'

EOF` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856562ebda4832e8542a41e7f8bd2d1