### PR TITLE
Improve prompts2tables for pairwise processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ Convert image prompts into organized CSV tables:
 python prompts2tables.py
 ```
 
-**Features:**
-- Parses multiple prompt files simultaneously
+-**Features:**
+- Option to process prompt files individually or in pairs (helps stay under the API token limit)
 - Extracts scene, shot, and prompt data
 - Outputs clean CSV format for easy management
+
+Processing files individually is recommended for very large directories to keep each request under Gemini's ~32k token limit (around 100-115 shots).
 
 **Output:** CSV tables saved to `text_files/image_prompts_tables/`
 


### PR DESCRIPTION
## Summary
- allow processing prompt files individually or in pairs
- document new option in README
- clarify docstrings and add inline notes

## Testing
- `python -m py_compile script2shots.py shots2prompts_IMGN.py shots2prompts_MJ.py prompts2tables.py tables_consolidate.py table2images.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685659d2369c832e86cba2cc7481f194